### PR TITLE
[Enhancement] Maintain Imports, and Add Docstring

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,22 @@ main directory of this repository.
 
 ## Configured Options
 
-| Option    | Brief | Meaning                                                  |
-|:---------:|:-----:|:---------------------------------------------------------|
-| `--help`  | `-h`  | Show this help and exit.                                 |
+| Option                    | Brief | Meaning                                                                   |
+|:-------------------------:|:-----:|:--------------------------------------------------------------------------|
+| `--author-contains`       | `-a`  | (**OR**) Filter for certain author names.                                 |
+| `--author-equals`         |       | (**OR**) Filter for certain author names.                                 |
+| `--commit-contains`       | `-c`  | (**OR**) Filter for certain commit hashes.                                |
+| `--commit-equals`         |       | (**OR**) Filter for certain commit hashes.                                |
+| `--email-contains`        | `-e`  | (**OR**) Filter for certain author emails.                                |
+| `--email-equals`          |       | (**OR**) Filter for certain author emails.                                |
+| `--duration`              | `-d`  | The time which may pass between two commits that still counts as working. |
+| `--file-extension`        | `-f`  | (**OR**) Filter loc for certain file extension, e.g.`-f cpp`.             |
+| `--help`                  | `-h`  | Show this help and exit.                                                  |
+| `--message-contains`      | `-m`  | (**OR**) Filter for certain commit messages.                              |
+| `--message-equals`        |       | (**OR**) Filter for certain commit messages.                              |
+| `--message-starts-with`   | `-l`  | (**OR**) Filter for certain commit messages.                              |
+| `--output`                | `-o`  | An output file for the commits per day in CSV format.                     |
+| `--quiet`                 | `-q`  | Hide the output of commit messages.                                       |
 
+Options marked with **OR** in their explanation can be specified multiple times
+and will be evaluated by joining them using the logical OR (`||`).

--- a/README.md
+++ b/README.md
@@ -26,3 +26,10 @@ commit-analyzer outputfile.txt --output "commits-and-loc-by-date.csv"
 
 This project's license is **MIT**.  The license can be found `LICENSE` in the
 main directory of this repository.
+
+## Configured Options
+
+| Option    | Brief | Meaning                                                  |
+|:---------:|:-----:|:---------------------------------------------------------|
+| `--help`  | `-h`  | Show this help and exit.                                 |
+

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,6 +1,8 @@
 use chrono::{DateTime, Duration, FixedOffset, ParseError};
 use getopts::Options;
-use std::{collections::HashMap, error::Error, io::Write, num::ParseIntError, ops::AddAssign};
+use std::{
+    collections::HashMap, env, error::Error, fs, io::Write, num::ParseIntError, ops::AddAssign
+};
 
 fn main() -> Result<(), Box<dyn Error>> {
     let mut opts = Options::new();
@@ -79,7 +81,7 @@ fn main() -> Result<(), Box<dyn Error>> {
             "An output file for the commits per day in csv format.",
             "FILE",
         );
-    let matches = match opts.parse(std::env::args()) {
+    let matches = match opts.parse(env::args()) {
         Ok(it) => it,
         Err(err) => {
             usage(opts);
@@ -101,7 +103,7 @@ fn main() -> Result<(), Box<dyn Error>> {
     };
     let path = matches.opt_str("output");
     let commits_path = &matches.free[1];
-    let commits = std::fs::read_to_string(commits_path).unwrap();
+    let commits = fs::read_to_string(commits_path).unwrap();
     let mut commits = commits.as_str();
     let mut parsed_commits = vec![];
     while !commits.is_empty() {
@@ -162,7 +164,7 @@ fn main() -> Result<(), Box<dyn Error>> {
     println!("Found {} commits overall", commit_count);
 
     if let Some(path) = path {
-        let mut file = std::fs::File::create(path)?;
+        let mut file = fs::File::create(path)?;
         let mut sorted_per_day_data = vec![];
         for key in commits_per_day.keys() {
             let commit_count = commits_per_day[key];

--- a/src/main.rs
+++ b/src/main.rs
@@ -3,78 +3,78 @@ use std::{collections::HashMap, error::Error, fs, io::Write, num::ParseIntError,
 fn main() -> Result<(), Box<dyn Error>> {
     let mut opts = getopts::Options::new();
     let opts = opts
-        .optflag("q", "quiet", "Hides the output of commit messages.")
+        .optflag("q", "quiet", "Hide the output of commit messages.")
         .optflag("h", "help", "Show this help and exit.")
         .optmulti(
             "a",
             "author-contains",
-            "Filters after certain author names. ORs if multiple specified.",
+            "Filter for certain author names. ORs if multiple specified.",
             "NAME",
         )
         .optmulti(
             "",
             "author-equals",
-            "Filters after certain author names. ORs if multiple specified.",
+            "Filter for certain author names. ORs if multiple specified.",
             "NAME",
         )
         .optmulti(
             "e",
             "email-contains",
-            "Filters after certain author emails. ORs if multiple specified.",
+            "Filter for certain author emails. ORs if multiple specified.",
             "EMAIL",
         )
         .optmulti(
             "",
             "email-equals",
-            "Filters after certain author emails. ORs if multiple specified.",
+            "Filter for certain author emails. ORs if multiple specified.",
             "EMAIL",
         )
         .optmulti(
             "c",
             "commit-contains",
-            "Filters after certain commit hashes. ORs if multiple specified.",
+            "Filter for certain commit hashes. ORs if multiple specified.",
             "HASH",
         )
         .optmulti(
             "",
             "commit-equals",
-            "Filters after certain commit hashes. ORs if multiple specified.",
+            "Filter for certain commit hashes. ORs if multiple specified.",
             "HASH",
         )
         .optmulti(
             "m",
             "message-contains",
-            "Filters after certain commit messages. ORs if multiple specified.",
+            "Filter for certain commit messages. ORs if multiple specified.",
             "MESSAGE",
         )
         .optmulti(
             "",
             "message-equals",
-            "Filters after certain commit messages. ORs if multiple specified.",
+            "Filter for certain commit messages. ORs if multiple specified.",
             "MESSAGE",
         )
         .optmulti(
             "l",
             "message-starts-with",
-            "Filters after certain commit messages. ORs if multiple specified.",
+            "Filter for certain commit messages. ORs if multiple specified.",
             "MESSAGE",
         )
         .optmulti(
             "f",
             "file-extension",
-            "Filters loc after certain file extension (e.g. `--file-extension cpp`). ORs if multiple specified.",
+            "Filter loc for certain file extension (e.g. `--file-extension cpp`). ORs if multiple specified.",
             "EXTENSION",
         )
         .optopt(
             "d",
             "duration",
-            "The time, which may pass between two commits, that still counts as working.",
+            "The time which may pass between two commits that still counts as working.",
             "HOURS",
         )
         .optopt(
             "o",
             "output",
-            "An output file for the commits per day in csv format.",
+            "An output file for the commits per day in CSV format.",
             "FILE",
         );
     let matches = match opts.parse(std::env::args()) {
@@ -184,7 +184,7 @@ fn main() -> Result<(), Box<dyn Error>> {
 fn usage(options: &getopts::Options) {
     println!(
         "Parses the output of `git log`.\n\n{}",
-        options.usage("Usage:  commit-analyzer <FILE> [OPTIONS]")
+        options.usage("Usage: commit-analyzer <FILE> [OPTIONS]")
     );
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,8 +1,7 @@
-use getopts::Options;
 use std::{collections::HashMap, error::Error, fs, io::Write, num::ParseIntError, ops::AddAssign};
 
 fn main() -> Result<(), Box<dyn Error>> {
-    let mut opts = Options::new();
+    let mut opts = getopts::Options::new();
     let opts = opts
         .optflag("q", "quiet", "Hides the output of commit messages.")
         .optflag("h", "help", "Show this help and exit.")
@@ -182,7 +181,7 @@ fn main() -> Result<(), Box<dyn Error>> {
 ///
 /// This function will write a brief usage information, including a short
 /// introduction to the meaning of the configured `options`, to `stdout`.
-fn usage(options: &Options) {
+fn usage(options: &getopts::Options) {
     println!(
         "Parses the output of `git log`.\n\n{}",
         options.usage("Usage:  commit-analyzer <FILE> [OPTIONS]")

--- a/src/main.rs
+++ b/src/main.rs
@@ -192,6 +192,10 @@ fn usage(options: &Options) {
     );
 }
 
+/// An abbreviation for the filter checks.
+///
+/// This function checks whether the given `commit` matches the expectations
+/// defined in the given `filter`.
 fn matches_filter(commit: &Commit, filter: &Filter) -> bool {
     filter.check_author_name(&commit.author.name)
         && filter.check_author_email(&commit.author.email)

--- a/src/main.rs
+++ b/src/main.rs
@@ -187,8 +187,8 @@ fn main() -> Result<(), Box<dyn Error>> {
 /// introduction to the meaning of the configured `options`, to `stdout`.
 fn usage(options: &Options) {
     println!(
-        "Usage:  commit-analyzer <FILE> [OPTIONS]\n\n{}",
-        options.usage("Parses the output of `git log`.")
+        "Parses the output of `git log`.\n\n{}",
+        options.usage("Usage:  commit-analyzer <FILE> [OPTIONS]")
     );
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,7 +1,7 @@
 use chrono::{DateTime, Duration, FixedOffset, ParseError};
 use getopts::Options;
 use std::{
-    collections::HashMap, env, error::Error, fs, io::Write, num::ParseIntError, ops::AddAssign
+    collections::HashMap, env, error::Error, fs, io::Write, num::ParseIntError, ops::AddAssign,
 };
 
 fn main() -> Result<(), Box<dyn Error>> {

--- a/src/main.rs
+++ b/src/main.rs
@@ -181,7 +181,7 @@ fn main() -> Result<(), Box<dyn Error>> {
     Ok(())
 }
 
-/// A small in-app documentation.
+/// A brief in-app documentation.
 ///
 /// This function will write a brief usage information, including a short
 /// introduction to the meaning of the configured `options`, to `stdout`.

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,3 +1,4 @@
+use chrono::{DateTime, Duration, FixedOffset, ParseError};
 use getopts::Options;
 use std::{collections::HashMap, error::Error, io::Write, num::ParseIntError, ops::AddAssign};
 
@@ -117,7 +118,7 @@ fn main() -> Result<(), Box<dyn Error>> {
         }
     }
     let mut last_time = None;
-    let mut duration = chrono::Duration::zero();
+    let mut duration = Duration::zero();
     let filter = Filter {
         author_equals: matches.opt_strs("author-equals"),
         author_contains: matches.opt_strs("author-contains"),
@@ -145,7 +146,7 @@ fn main() -> Result<(), Box<dyn Error>> {
                 .or_insert(0)
                 .add_assign(commit.loc(&filter));
             if let Some(last_time) = last_time {
-                let diff: chrono::Duration = commit.date - last_time;
+                let diff: Duration = commit.date - last_time;
                 if diff.num_hours() <= max_diff_hours as i64 {
                     duration = duration + diff;
                 }
@@ -261,7 +262,7 @@ enum CommitParseError {
     AuthorMissing,
     DateMissing,
     AuthorFailed(AuthorParseError),
-    DateFailed(chrono::ParseError),
+    DateFailed(ParseError),
     LocSyntaxError,
     LocFailed(LocParseError),
     Unknown,
@@ -344,7 +345,7 @@ fn parse_commit(commit: &str) -> Result<(Commit, &str), CommitParseError> {
         commit: commit.into(),
         merge,
         author: Author::parse(author).map_err(CommitParseError::AuthorFailed)?,
-        date: chrono::DateTime::parse_from_str(date, "%a %b %e %T %Y %z")
+        date: DateTime::parse_from_str(date, "%a %b %e %T %Y %z")
             .map_err(CommitParseError::DateFailed)?,
         message: message.into(),
         locs,
@@ -360,7 +361,7 @@ pub struct Commit {
     #[allow(dead_code)]
     merge: Option<String>,
     author: Author,
-    date: chrono::DateTime<chrono::FixedOffset>,
+    date: DateTime<FixedOffset>,
     message: String,
     locs: Vec<Loc>,
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -2,7 +2,7 @@ use getopts::Options;
 use std::{collections::HashMap, error::Error, io::Write, num::ParseIntError, ops::AddAssign};
 
 fn main() -> Result<(), Box<dyn Error>> {
-    let mut opts = getopts::Options::new();
+    let mut opts = Options::new();
     let opts = opts
         .optflag("q", "quiet", "Hides the output of commit messages.")
         .optflag("h", "help", "Show this help and exit.")

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,4 +1,3 @@
-use chrono::{DateTime, Duration, FixedOffset, ParseError};
 use getopts::Options;
 use std::{
     collections::HashMap, env, error::Error, fs, io::Write, num::ParseIntError, ops::AddAssign,
@@ -120,7 +119,7 @@ fn main() -> Result<(), Box<dyn Error>> {
         }
     }
     let mut last_time = None;
-    let mut duration = Duration::zero();
+    let mut duration = chrono::Duration::zero();
     let filter = Filter {
         author_equals: matches.opt_strs("author-equals"),
         author_contains: matches.opt_strs("author-contains"),
@@ -148,7 +147,7 @@ fn main() -> Result<(), Box<dyn Error>> {
                 .or_insert(0)
                 .add_assign(commit.loc(&filter));
             if let Some(last_time) = last_time {
-                let diff: Duration = commit.date - last_time;
+                let diff: chrono::Duration = commit.date - last_time;
                 if diff.num_hours() <= max_diff_hours as i64 {
                     duration = duration + diff;
                 }
@@ -268,7 +267,7 @@ enum CommitParseError {
     AuthorMissing,
     DateMissing,
     AuthorFailed(AuthorParseError),
-    DateFailed(ParseError),
+    DateFailed(chrono::ParseError),
     LocSyntaxError,
     LocFailed(LocParseError),
     Unknown,
@@ -351,7 +350,7 @@ fn parse_commit(commit: &str) -> Result<(Commit, &str), CommitParseError> {
         commit: commit.into(),
         merge,
         author: Author::parse(author).map_err(CommitParseError::AuthorFailed)?,
-        date: DateTime::parse_from_str(date, "%a %b %e %T %Y %z")
+        date: chrono::DateTime::parse_from_str(date, "%a %b %e %T %Y %z")
             .map_err(CommitParseError::DateFailed)?,
         message: message.into(),
         locs,
@@ -367,7 +366,7 @@ pub struct Commit {
     #[allow(dead_code)]
     merge: Option<String>,
     author: Author,
-    date: DateTime<FixedOffset>,
+    date: chrono::DateTime<chrono::FixedOffset>,
     message: String,
     locs: Vec<Loc>,
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,7 +1,5 @@
 use getopts::Options;
-use std::{
-    collections::HashMap, env, error::Error, fs, io::Write, num::ParseIntError, ops::AddAssign,
-};
+use std::{collections::HashMap, error::Error, fs, io::Write, num::ParseIntError, ops::AddAssign};
 
 fn main() -> Result<(), Box<dyn Error>> {
     let mut opts = Options::new();
@@ -80,7 +78,7 @@ fn main() -> Result<(), Box<dyn Error>> {
             "An output file for the commits per day in csv format.",
             "FILE",
         );
-    let matches = match opts.parse(env::args()) {
+    let matches = match opts.parse(std::env::args()) {
         Ok(it) => it,
         Err(err) => {
             usage(opts);

--- a/src/main.rs
+++ b/src/main.rs
@@ -8,61 +8,61 @@ fn main() -> Result<(), Box<dyn Error>> {
         .optmulti(
             "a",
             "author-contains",
-            "Filter for certain author names. ORs if multiple specified.",
+            "Filter for certain author names. ORs if specified multiple times.",
             "NAME",
         )
         .optmulti(
             "",
             "author-equals",
-            "Filter for certain author names. ORs if multiple specified.",
+            "Filter for certain author names. ORs if specified multiple times.",
             "NAME",
         )
         .optmulti(
             "e",
             "email-contains",
-            "Filter for certain author emails. ORs if multiple specified.",
+            "Filter for certain author emails. ORs if specified multiple times.",
             "EMAIL",
         )
         .optmulti(
             "",
             "email-equals",
-            "Filter for certain author emails. ORs if multiple specified.",
+            "Filter for certain author emails. ORs if specified multiple times.",
             "EMAIL",
         )
         .optmulti(
             "c",
             "commit-contains",
-            "Filter for certain commit hashes. ORs if multiple specified.",
+            "Filter for certain commit hashes. ORs if specified multiple times.",
             "HASH",
         )
         .optmulti(
             "",
             "commit-equals",
-            "Filter for certain commit hashes. ORs if multiple specified.",
+            "Filter for certain commit hashes. ORs if specified multiple times.",
             "HASH",
         )
         .optmulti(
             "m",
             "message-contains",
-            "Filter for certain commit messages. ORs if multiple specified.",
+            "Filter for certain commit messages. ORs if specified multiple times.",
             "MESSAGE",
         )
         .optmulti(
             "",
             "message-equals",
-            "Filter for certain commit messages. ORs if multiple specified.",
+            "Filter for certain commit messages. ORs if specified multiple times.",
             "MESSAGE",
         )
         .optmulti(
             "l",
             "message-starts-with",
-            "Filter for certain commit messages. ORs if multiple specified.",
+            "Filter for certain commit messages. ORs if specified multiple times.",
             "MESSAGE",
         )
         .optmulti(
             "f",
             "file-extension",
-            "Filter loc for certain file extension (e.g. `--file-extension cpp`). ORs if multiple specified.",
+            "Filter loc for certain file extension (e.g. `--file-extension cpp`). ORs if specified multiple times.",
             "EXTENSION",
         )
         .optopt(


### PR DESCRIPTION
These changes introduce

* a maintenance of the module import, and
* a new docstring for the syntactic sugar function `matches_filter`.

Since the defined crate has two dependencies defined in its `Cargo.toml`, it might help to import the required modules explicitly.  This not only benefits the readability of the file but also justifies them being listed as dependencies.

Furthermore, since there already is an import line for `std` modules, I added the other components which are requested but not imported at the file's beginning, yet.

The changes are linted and formatted.