### PR TITLE
[Enhancement] Explicit Handling of Unknown Command Line Option

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -27,6 +27,7 @@ version = "0.1.0"
 dependencies = [
  "chrono",
  "getopts",
+ "sysexits",
 ]
 
 [[package]]
@@ -62,6 +63,12 @@ checksum = "9a64b1ec5cda2586e284722486d802acf1f7dbdc623e2bfc57e65ca1cd099290"
 dependencies = [
  "autocfg",
 ]
+
+[[package]]
+name = "sysexits"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d5f3c147073b163781e173405eb888683bf1c2d2f8604396a0727bf7fddb4e8"
 
 [[package]]
 name = "time"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,3 +8,4 @@ edition = "2021"
 [dependencies]
 chrono = "*"
 getopts = "*"
+sysexits = "*"

--- a/src/main.rs
+++ b/src/main.rs
@@ -81,8 +81,17 @@ fn main() -> Result<(), Box<dyn Error>> {
         );
     let matches = match opts.parse(std::env::args()) {
         Ok(it) => it,
+        Err(getopts::Fail::UnrecognizedOption(string)) => {
+            println!(
+                "{}",
+                opts.usage(&format!(
+                    "Unknown option '{string}'! Please rerun with one of these:"
+                ))
+            );
+            // Quit the application with `EX_USAGE` from `sysexits.h`.
+            std::process::exit(64i32);
+        }
         Err(err) => {
-            commit_analyzer::usage(opts);
             return Err(err.into());
         }
     };

--- a/src/main.rs
+++ b/src/main.rs
@@ -82,14 +82,7 @@ fn main() -> Result<(), Box<dyn Error>> {
     let matches = match opts.parse(std::env::args()) {
         Ok(it) => it,
         Err(getopts::Fail::UnrecognizedOption(string)) => {
-            println!(
-                "{}",
-                opts.usage(&format!(
-                    "Unknown option '{string}'! Please rerun with some of these:"
-                    // "Unknown option '{string}'. The configured options are as follows:"
-                    // "Unresolvable argument: '{string}'. Valid options are as follows:"
-                ))
-            );
+            eprintln!("{}", opts.usage(&format!("Unknown option '{string}'.")));
             // Quit the application with `EX_USAGE` from `sysexits.h`.
             std::process::exit(64);
         }

--- a/src/main.rs
+++ b/src/main.rs
@@ -85,11 +85,13 @@ fn main() -> Result<(), Box<dyn Error>> {
             println!(
                 "{}",
                 opts.usage(&format!(
-                    "Unknown option '{string}'! Please rerun with one of these:"
+                    "Unknown option '{string}'! Please rerun with some of these:"
+                    // "Unknown option '{string}'. The configured options are as follows:"
+                    // "Unresolvable argument: '{string}'. Valid options are as follows:"
                 ))
             );
             // Quit the application with `EX_USAGE` from `sysexits.h`.
-            std::process::exit(64i32);
+            std::process::exit(64);
         }
         Err(err) => {
             return Err(err.into());

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,6 +1,6 @@
-use std::{collections::HashMap, error::Error, io::Write, ops::AddAssign};
+use std::{collections::HashMap, io::Write, ops::AddAssign};
 
-fn main() -> Result<(), Box<dyn Error>> {
+fn main() -> sysexits::ExitCode {
     let mut opts = getopts::Options::new();
     let opts = opts
         .optflag("", "git", "Grab the input data from the local Git history.")
@@ -83,37 +83,47 @@ fn main() -> Result<(), Box<dyn Error>> {
         Ok(it) => it,
         Err(getopts::Fail::UnrecognizedOption(string)) => {
             eprintln!("{}", opts.usage(&format!("Unknown option '{string}'.")));
-            // Quit the application with `EX_USAGE` from `sysexits.h`.
-            std::process::exit(64);
+            return sysexits::ExitCode::Usage;
         }
         Err(err) => {
-            return Err(err.into());
+            eprintln!("{}", opts.usage(&format!("{err}")));
+            return sysexits::ExitCode::Config;
         }
     };
     if matches.opt_present("help") || (!matches.opt_present("git") && !matches.opt_present("input"))
     {
         commit_analyzer::usage(opts);
-        return Ok(());
+        return sysexits::ExitCode::Ok;
     }
     let is_verbose = matches.opt_present("verbose");
     let max_diff_hours: u32 = match matches.opt_str("duration").map(|str| str.parse()) {
         None => 3,
         Some(Ok(it)) => it,
-        Some(Err(err)) => {
+        Some(Err(_)) => {
             eprintln!("duration must be an integer value!");
-            return Err(err.into());
+            return sysexits::ExitCode::Usage;
         }
     };
     let path = matches.opt_str("output");
     let commits = if matches.opt_present("git") {
-        let process = std::process::Command::new("git")
+        let process = match std::process::Command::new("git")
             .arg("log")
             .arg("--numstat")
-            .output()?;
-        String::from_utf8(process.stdout)?
+            .output()
+        {
+            Ok(out) => out,
+            Err(_) => return sysexits::ExitCode::Unavailable,
+        };
+        match String::from_utf8(process.stdout) {
+            Ok(string) => string,
+            Err(_) => return sysexits::ExitCode::DataErr,
+        }
     } else if matches.opt_present("input") {
         let path = matches.opt_str("input").unwrap();
-        std::fs::read_to_string(path)?
+        match std::fs::read_to_string(path) {
+            Ok(string) => string,
+            Err(_) => return sysexits::ExitCode::IoErr,
+        }
     } else {
         todo!("Read Git history from `stdin`.");
     };
@@ -166,7 +176,10 @@ fn main() -> Result<(), Box<dyn Error>> {
     println!("Found {} commits overall", commit_count);
 
     if let Some(path) = path {
-        let mut file = std::fs::File::create(path)?;
+        let mut file = match std::fs::File::create(path) {
+            Ok(file) => file,
+            Err(_) => return sysexits::ExitCode::CantCreat,
+        };
         let mut sorted_per_day_data = vec![];
         for key in commits_per_day.keys() {
             let commit_count = commits_per_day[key];
@@ -174,11 +187,17 @@ fn main() -> Result<(), Box<dyn Error>> {
             sorted_per_day_data.push((*key, commit_count, loc));
         }
         sorted_per_day_data.sort_by_cached_key(|(k, _, _)| *k);
-        writeln!(file, "Date, Commits, Loc")?;
+        match writeln!(file, "Date, Commits, Loc") {
+            Ok(something) => something,
+            Err(_) => return sysexits::ExitCode::IoErr,
+        };
         for (date, commits, loc) in sorted_per_day_data {
-            writeln!(file, "{}, {}, {}", date, commits, loc)?;
+            match writeln!(file, "{}, {}, {}", date, commits, loc) {
+                Ok(something) => something,
+                Err(_) => return sysexits::ExitCode::IoErr,
+            };
         }
     }
 
-    Ok(())
+    sysexits::ExitCode::Ok
 }


### PR DESCRIPTION
This change introduces the dedicated handling of the most common reason for the command line argument parsing against the configured options to fail:  an unknown option.

The unknown option will be named and the configured ones will be printed as recommended set to rerun the application with.  The return status will be set to the corresponding value from `sysexits.h` in order to indicate the error appropriately.

In case the error should not arise from an unknown option, it will be prompted such that it cannot be overseen.  This makes fixing the cause easier in comparison to the previous behaviour of the application.