### PR TITLE
Use `clap` instead of `getopts` to parse cli args

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -40,9 +40,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "3.2.3"
+version = "3.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1df386a2d0f35bdefc0642fd8bcb2cd28243959f028abfd22fbade6f7d30980e"
+checksum = "9f1fe12880bae935d142c8702d500c63a4e8634b6c3c57ad72bf978fc7b6249a"
 dependencies = [
  "atty",
  "bitflags",
@@ -57,9 +57,9 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "3.2.3"
+version = "3.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b740354ad9fcf20e27b46d921be4bb3712f5b3c2c7a89ba68a72a8e51d3a47f"
+checksum = "ed6db9e867166a43a53f7199b5e4d1f522a1e5bd626654be263c999ce59df39a"
 dependencies = [
  "heck",
  "proc-macro-error",
@@ -70,9 +70,9 @@ dependencies = [
 
 [[package]]
 name = "clap_lex"
-version = "0.2.2"
+version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5538cd660450ebeb4234cfecf8f2284b844ffc4c50531e66d584ad5b91293613"
+checksum = "87eba3c8c7f42ef17f6c659fc7416d0f4758cd3e58861ee63c5fa4a4dde649e4"
 dependencies = [
  "os_str_bytes",
 ]
@@ -88,9 +88,9 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
-version = "0.11.2"
+version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab5ef0d4909ef3724cc8cce6ccc8572c5c817592e9285f5464f8e86f8bd3726e"
+checksum = "db0d4cf898abf0081f964436dc980e96670a0f36863e4b83aaacdb65c9d7ccc3"
 
 [[package]]
 name = "heck"
@@ -109,9 +109,9 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "1.8.2"
+version = "1.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e6012d540c5baa3589337a98ce73408de9b5a25ec9fc2c6fd6be8f0d39e0ca5a"
+checksum = "10a35a97730320ffe8e2d410b5d3b69279b98d2c14bdb8b70ea89ecf7888d41e"
 dependencies = [
  "autocfg",
  "hashbrown",
@@ -180,18 +180,18 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.39"
+version = "1.0.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c54b25569025b7fc9651de43004ae593a75ad88543b17178aa5e1b9c4f15f56f"
+checksum = "dd96a1e8ed2596c337f8eae5f24924ec83f5ad5ab21ea8e455d3566c69fbcaf7"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
 name = "quote"
-version = "1.0.18"
+version = "1.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1feb54ed693b93a84e14094943b84b7c4eae204c512b7ccb95ab0c66d278ad1"
+checksum = "3bcdf212e9776fbcb2d23ab029360416bb1706b1aea2d1a5ba002727cbcab804"
 dependencies = [
  "proc-macro2",
 ]
@@ -204,9 +204,9 @@ checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
 
 [[package]]
 name = "syn"
-version = "1.0.96"
+version = "1.0.98"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0748dd251e24453cb8717f0354206b91557e4ec8703673a4b30208f2abaf1ebf"
+checksum = "c50aef8a904de4c23c788f104b7dddc7d6f79c647c7c8ce4cc8f73eb0ca773dd"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,10 +3,27 @@
 version = 3
 
 [[package]]
-name = "autocfg"
-version = "1.0.1"
+name = "atty"
+version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cdb031dd78e28731d87d56cc8ffef4a8f36ca26c38fe2de700543e627f8a464a"
+checksum = "d9b39be18770d11421cdb1b9947a45dd3f37e93092cbf377614828a319d5fee8"
+dependencies = [
+ "hermit-abi",
+ "libc",
+ "winapi",
+]
+
+[[package]]
+name = "autocfg"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
+
+[[package]]
+name = "bitflags"
+version = "1.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "chrono"
@@ -22,34 +39,95 @@ dependencies = [
 ]
 
 [[package]]
+name = "clap"
+version = "3.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1df386a2d0f35bdefc0642fd8bcb2cd28243959f028abfd22fbade6f7d30980e"
+dependencies = [
+ "atty",
+ "bitflags",
+ "clap_derive",
+ "clap_lex",
+ "indexmap",
+ "once_cell",
+ "strsim",
+ "termcolor",
+ "textwrap",
+]
+
+[[package]]
+name = "clap_derive"
+version = "3.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b740354ad9fcf20e27b46d921be4bb3712f5b3c2c7a89ba68a72a8e51d3a47f"
+dependencies = [
+ "heck",
+ "proc-macro-error",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "clap_lex"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5538cd660450ebeb4234cfecf8f2284b844ffc4c50531e66d584ad5b91293613"
+dependencies = [
+ "os_str_bytes",
+]
+
+[[package]]
 name = "commit-analyzer"
 version = "0.1.0"
 dependencies = [
  "chrono",
- "getopts",
+ "clap",
  "sysexits",
 ]
 
 [[package]]
-name = "getopts"
-version = "0.2.21"
+name = "hashbrown"
+version = "0.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "14dbbfd5c71d70241ecf9e6f13737f7b5ce823821063188d7e46c41d371eebd5"
+checksum = "ab5ef0d4909ef3724cc8cce6ccc8572c5c817592e9285f5464f8e86f8bd3726e"
+
+[[package]]
+name = "heck"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2540771e65fc8cb83cd6e8a237f70c319bd5c29f78ed1084ba5d50eeac86f7f9"
+
+[[package]]
+name = "hermit-abi"
+version = "0.1.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "62b467343b94ba476dcb2500d242dadbb39557df889310ac77c5d99100aaac33"
 dependencies = [
- "unicode-width",
+ "libc",
+]
+
+[[package]]
+name = "indexmap"
+version = "1.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6012d540c5baa3589337a98ce73408de9b5a25ec9fc2c6fd6be8f0d39e0ca5a"
+dependencies = [
+ "autocfg",
+ "hashbrown",
 ]
 
 [[package]]
 name = "libc"
-version = "0.2.116"
+version = "0.2.126"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "565dbd88872dbe4cc8a46e527f26483c1d1f7afa6b884a3bd6cd893d4f98da74"
+checksum = "349d5a591cd28b49e1d1037471617a32ddcda5731b99419008085f72d5a53836"
 
 [[package]]
 name = "num-integer"
-version = "0.1.44"
+version = "0.1.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d2cc698a63b549a70bc047073d2949cce27cd1c7b0a4a862d08a8031bc2801db"
+checksum = "225d3389fb3509a24c93f5c29eb6bde2586b98d9f016636dff58d7c6f7569cd9"
 dependencies = [
  "autocfg",
  "num-traits",
@@ -57,18 +135,104 @@ dependencies = [
 
 [[package]]
 name = "num-traits"
-version = "0.2.14"
+version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a64b1ec5cda2586e284722486d802acf1f7dbdc623e2bfc57e65ca1cd099290"
+checksum = "578ede34cf02f8924ab9447f50c28075b4d3e5b269972345e7e0372b38c6cdcd"
 dependencies = [
  "autocfg",
 ]
 
 [[package]]
-name = "sysexits"
-version = "0.2.1"
+name = "once_cell"
+version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d5f3c147073b163781e173405eb888683bf1c2d2f8604396a0727bf7fddb4e8"
+checksum = "7709cef83f0c1f58f666e746a08b21e0085f7440fa6a29cc194d68aac97a4225"
+
+[[package]]
+name = "os_str_bytes"
+version = "6.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "21326818e99cfe6ce1e524c2a805c189a99b5ae555a35d19f9a284b427d86afa"
+
+[[package]]
+name = "proc-macro-error"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da25490ff9892aab3fcf7c36f08cfb902dd3e71ca0f9f9517bea02a73a5ce38c"
+dependencies = [
+ "proc-macro-error-attr",
+ "proc-macro2",
+ "quote",
+ "syn",
+ "version_check",
+]
+
+[[package]]
+name = "proc-macro-error-attr"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1be40180e52ecc98ad80b184934baf3d0d29f979574e439af5a55274b35f869"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "version_check",
+]
+
+[[package]]
+name = "proc-macro2"
+version = "1.0.39"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c54b25569025b7fc9651de43004ae593a75ad88543b17178aa5e1b9c4f15f56f"
+dependencies = [
+ "unicode-ident",
+]
+
+[[package]]
+name = "quote"
+version = "1.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1feb54ed693b93a84e14094943b84b7c4eae204c512b7ccb95ab0c66d278ad1"
+dependencies = [
+ "proc-macro2",
+]
+
+[[package]]
+name = "strsim"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
+
+[[package]]
+name = "syn"
+version = "1.0.96"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0748dd251e24453cb8717f0354206b91557e4ec8703673a4b30208f2abaf1ebf"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
+
+[[package]]
+name = "sysexits"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57c24dea646d0a2a4209a2d960275fd4416be9ab32c77927f51279a621e2b629"
+
+[[package]]
+name = "termcolor"
+version = "1.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bab24d30b911b2376f3a13cc2cd443142f0c81dda04c118693e35b3835757755"
+dependencies = [
+ "winapi-util",
+]
+
+[[package]]
+name = "textwrap"
+version = "0.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b1141d4d61095b28419e22cb0bbf02755f5e54e0526f97f1e3d1d160e60885fb"
 
 [[package]]
 name = "time"
@@ -82,10 +246,16 @@ dependencies = [
 ]
 
 [[package]]
-name = "unicode-width"
-version = "0.1.9"
+name = "unicode-ident"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3ed742d4ea2bd1176e236172c8429aaf54486e7ac098db29ffe6529e0ce50973"
+checksum = "5bd2fe26506023ed7b5e1e315add59d6f584c621d037f9368fea9cfb988f368c"
+
+[[package]]
+name = "version_check"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
 
 [[package]]
 name = "wasi"
@@ -108,6 +278,15 @@ name = "winapi-i686-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
+
+[[package]]
+name = "winapi-util"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70ec6ce85bb158151cae5e5c87f95a8e97d2c0c4b001223f33a334e3ce5de178"
+dependencies = [
+ "winapi",
+]
 
 [[package]]
 name = "winapi-x86_64-pc-windows-gnu"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,11 +1,14 @@
 [package]
-name = "commit-analyzer"
-version = "0.1.0"
+categories = ["command-line-utilities"]
+description = "Gets the time somebody worked on something from `git log`."
 edition = "2021"
-
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+keywords = ["cli", "git", "summary", "time"]
+license = "MIT"
+name = "commit-analyzer"
+repository = "https://github.com/wert007/commit-analyzer"
+version = "0.1.0"
 
 [dependencies]
-chrono = "*"
-clap = { version = "*", features = ["derive"] }
-sysexits = "*"
+chrono = "0.4.19"
+clap = { version = "3.2.6", features = ["derive"] }
+sysexits = "0.3.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,5 +7,5 @@ edition = "2021"
 
 [dependencies]
 chrono = "*"
-getopts = "*"
+clap = { version = "*", features = ["derive"] }
 sysexits = "*"

--- a/README.md
+++ b/README.md
@@ -68,15 +68,3 @@ cargo install --git https://github.com/wert007/commit-analyzer
 This command will install a release compilation of the latest version locally to
 your user account. The same command also works for regular updates, this is, new
 commits have had been introduced since the last installation.
-
-Cargo will refuse to replace the currently installed executable if no new
-commits were found. To override the current binary with the latest repository 
-state anyway, rerun with `--force`:
-
-```
-cargo install --force --git https://github.com/wert007/commit-analyzer
-```
-
-Cargo will then replace the currently installed release binary with a newly
-compiled one from the latest repository state using the configured release
-profile.

--- a/README.md
+++ b/README.md
@@ -1,5 +1,9 @@
 # Commit Analyzer
 
+## Summary
+
+Gets the time somebody worked on something from `git log`.
+
 ## Description
 
 This is a simple tool which grabs the output of `git log --numstat` and analyzes

--- a/README.md
+++ b/README.md
@@ -4,6 +4,11 @@
 
 Gets the time somebody worked on something from `git log`.
 
+## License
+
+This project's license is **MIT** and can be found in `LICENSE` in the main
+directory of this repository.
+
 ## Description
 
 This is a simple tool which grabs the output of `git log --numstat` and analyzes
@@ -25,11 +30,6 @@ changes due to them.
 commit-analyzer --git --output commits-and-loc-by-date.csv
 commit-analyzer --input git.log --output commits-and-loc-by-date.csv
 ```
-
-## License
-
-This project's license is **MIT** and can be found in `LICENSE` in the main
-directory of this repository.
 
 ## Configured Options
 
@@ -66,9 +66,12 @@ cargo install --git https://github.com/wert007/commit-analyzer
 ```
 
 This command will install a release compilation of the latest version locally to
-your user account.
+your user account. The same command also works for regular updates, this is, new
+commits have had been introduced since the last installation.
 
-In order to install the latest updates, rerun with `--force`:
+Cargo will refuse to replace the currently installed executable if no new
+commits were found. To override the current binary with the latest repository 
+state anyway, rerun with `--force`:
 
 ```
 cargo install --force --git https://github.com/wert007/commit-analyzer

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -90,6 +90,23 @@ impl Args {
     pub fn take_output(&mut self) -> Option<PathBuf> {
         self.output.take()
     }
+
+    /// Creates a new Filter as specified by the user.
+    #[must_use]
+    pub fn filter(&self) -> Filter {
+        Filter {
+            author_contains: &self.author_contains,
+            author_equals: &self.author_equals,
+            commit_contains: &self.commit_contains,
+            commit_equals: &self.commit_equals,
+            email_contains: &self.email_contains,
+            email_equals: &self.email_equals,
+            file_extension: &self.file_extension,
+            message_contains: &self.message_contains,
+            message_equals: &self.message_equals,
+            message_starts_with: &self.message_starts_with,
+        }
+    }
 }
 
 /// The possible input methods.
@@ -145,39 +162,39 @@ impl InputMethod {
 ///
 /// This data structure allows to filter the input commits by certain criteria.
 #[derive(Debug, Default)]
-pub struct Filter {
+pub struct Filter<'a> {
     /// A set of substrings to be contained by some authors' names.
-    author_contains: Vec<String>,
+    author_contains: &'a [String],
 
     /// A set of strings to match some authors's names.
-    author_equals: Vec<String>,
+    author_equals: &'a [String],
 
     /// A set of substrings to be contained by some commits' hashes.
-    commit_contains: Vec<String>,
+    commit_contains: &'a [String],
 
     /// A set of strings to match some commits' hashes.
-    commit_equals: Vec<String>,
+    commit_equals: &'a [String],
 
     /// A set of substrings to be contained by some authors' email addresses.
-    email_contains: Vec<String>,
+    email_contains: &'a [String],
 
     /// A set of strings to match some authors' email addresses.
-    email_equals: Vec<String>,
+    email_equals: &'a [String],
 
     /// A set of file extensions to filter by.
-    file_extension: Vec<String>,
+    file_extension: &'a [String],
 
     /// A set of substrings to be contained by some commits' messages.
-    message_contains: Vec<String>,
+    message_contains: &'a [String],
 
     /// A set of strings to match some commits' messages.
-    message_equals: Vec<String>,
+    message_equals: &'a [String],
 
     /// A set of strings to introduce some commits' messages.
-    message_starts_with: Vec<String>,
+    message_starts_with: &'a [String],
 }
 
-impl Filter {
+impl Filter<'_> {
     /// Whether the author's email address matches the expectations.
     fn check_author_email(&self, email: &str) -> bool {
         let contains =
@@ -239,22 +256,6 @@ impl Filter {
             && self.check_author_email(commit.author().email())
             && self.check_commit(commit.commit())
             && self.check_message(commit.message())
-    }
-
-    /// Create a new instance from a given set of filter criteria.
-    pub fn new(args: Args) -> Self {
-        Self {
-            author_contains: args.author_contains,
-            author_equals: args.author_equals,
-            commit_contains: args.commit_contains,
-            commit_equals: args.commit_equals,
-            email_contains: args.email_contains,
-            email_equals: args.email_equals,
-            file_extension: args.file_extension,
-            message_contains: args.message_contains,
-            message_equals: args.message_equals,
-            message_starts_with: args.message_starts_with,
-        }
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -544,27 +544,29 @@ pub struct Args {
 }
 
 impl Args {
-    /// Get a reference to the input method specified by the user.
+    /// Get the input method specified by the user.
     #[must_use]
     pub fn input_method(&self) -> &InputMethod {
         &self.input_method
     }
 
-    /// Get the expected verbosity of the program.
+    /// Get the configured verbosity level of the program.
     #[must_use]
     pub fn is_verbose(&self) -> bool {
         self.verbose
     }
 
-    /// Get the duration specified by the user, that may be marked as working
-    /// between to commits.
+    /// Get the maximum duration between two commits considered spent working.
     #[must_use]
     pub fn duration(&self) -> u32 {
         self.duration
     }
 
-    /// Takes the output path, specified by the user, out of `Args`. This should
-    /// therefore only be called once, but saves a unnecessary clone.
+    /// Takes the output path, specified by the user, out of `Args`.
+    ///
+    /// This method moves the specified path to the intended output file out of
+    /// this struct. This should therefore only be called once, but saves an
+    /// unnecessary clone.
     #[must_use]
     pub fn take_output(&mut self) -> Option<PathBuf> {
         self.output.take()

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,16 +8,16 @@ use clap::{Parser, Subcommand};
 #[derive(Parser, Debug)]
 #[clap(version, about, long_about = None)]
 pub struct Args {
-    /// Specifies how the program will read the git history.
+    /// Specifies how the program will read the Git history.
     #[clap(subcommand)]
     input_method: InputMethod,
 
-    /// Always show the entire output.
+    /// Always shows the entire output.
     #[clap(short = 'v', long = "verbose")]
     is_verbose: bool,
 
-    /// Filter the LOC diff for a certain file extension (e.g. `--file-extension
-    /// cpp`). ORs if specified multiple times.
+    /// Filters the LOC diff for a certain file extension (e.g.
+    /// `--file-extension cpp`). ORs if specified multiple times.
     #[clap(short, long)]
     file_extension: Vec<String>,
 
@@ -29,39 +29,39 @@ pub struct Args {
     #[clap(short, long)]
     output: Option<PathBuf>,
 
-    /// Filter for certain author names. ORs if specified multiple times.
+    /// Filters for certain author names. ORs if specified multiple times.
     #[clap(short, long)]
     author_contains: Vec<String>,
 
-    /// Filter for certain author names. ORs if specified multiple times.
+    /// Filters for certain author names. ORs if specified multiple times.
     #[clap(long)]
     author_equals: Vec<String>,
 
-    /// Filter for certain author emails. ORs if specified multiple times.
+    /// Filters for certain author emails. ORs if specified multiple times.
     #[clap(short, long)]
     email_contains: Vec<String>,
 
-    /// Filter for certain author emails. ORs if specified multiple times.
+    /// Filters for certain author emails. ORs if specified multiple times.
     #[clap(long)]
     email_equals: Vec<String>,
 
-    /// Filter for certain commit hashes. ORs if specified multiple times.
+    /// Filters for certain commit hashes. ORs if specified multiple times.
     #[clap(short, long)]
     commit_contains: Vec<String>,
 
-    /// Filter for certain commit hashes. ORs if specified multiple times.
+    /// Filters for certain commit hashes. ORs if specified multiple times.
     #[clap(long)]
     commit_equals: Vec<String>,
 
-    /// Filter for certain commit messages. ORs if specified multiple times.
+    /// Filters for certain commit messages. ORs if specified multiple times.
     #[clap(short, long)]
     message_contains: Vec<String>,
 
-    /// Filter for certain commit messages. ORs if specified multiple times.
+    /// Filters for certain commit messages. ORs if specified multiple times.
     #[clap(long)]
     message_equals: Vec<String>,
 
-    /// Filter for certain commit messages. ORs if specified multiple times.
+    /// Filters for certain commit messages. ORs if specified multiple times.
     #[clap(short = 'l', long)]
     message_starts_with: Vec<String>,
 }
@@ -116,21 +116,21 @@ impl Args {
 /// The possible input methods.
 #[derive(Subcommand, Debug)]
 pub enum InputMethod {
-    /// Read the input from the local Git history.
+    /// Reads the input from the local Git history.
     GitHistory,
 
-    /// Read the specified input file.
+    /// Reads the specified input file.
     LogFile {
         /// The log file to read from.
         log_file: PathBuf,
     },
 
-    /// Read from `stdin`.
+    /// Reads from `stdin`.
     Stdin,
 }
 
 impl InputMethod {
-    /// Process the configured input method.
+    /// Processes the configured input method.
     pub fn read(&self) -> Result<String, Box<dyn std::error::Error>> {
         match self {
             Self::GitHistory => {
@@ -292,7 +292,7 @@ impl Author {
         &self.name
     }
 
-    /// Extract the author information from the given line.
+    /// Extracts the author information from the given line.
     pub fn parse(author: &str) -> Result<Self, AuthorParseError> {
         let (name, remainder) = author.split_once('<').ok_or(AuthorParseError::NameFailed)?;
 
@@ -373,7 +373,7 @@ impl Commit {
         &self.message
     }
 
-    /// Construct a new instance from the raw input data.
+    /// Constructs a new instance from the raw input data.
     pub fn parse(commit: &str) -> Result<(Self, &str), CommitParseError> {
         let (commit, remainder) = commit
             .strip_prefix("commit")

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -492,11 +492,11 @@ pub enum LocParseError {
 #[clap(version, about, long_about = None)]
 pub struct Args {
     #[clap(subcommand)]
-    pub input_method: InputMethod,
+    input_method: InputMethod,
 
     /// Always show the entire output.
     #[clap(short, long)]
-    pub verbose: bool,
+    verbose: bool,
 
     /// Filter for certain author names. ORs if specified multiple times.
     #[clap(short, long)]
@@ -536,9 +536,37 @@ pub struct Args {
 
     /// The time which may pass between two commits that still counts as working.
     #[clap(short, long, default_value_t = 3)]
-    pub duration: u32,
+    duration: u32,
 
     /// An output file for the commits per day in CSV format.
     #[clap(short, long)]
-    pub output: Option<PathBuf>,
+    output: Option<PathBuf>,
+}
+
+impl Args {
+    /// Get a reference to the input method specified by the user.
+    #[must_use]
+    pub fn input_method(&self) -> &InputMethod {
+        &self.input_method
+    }
+
+    /// Get the expected verbosity of the program.
+    #[must_use]
+    pub fn is_verbose(&self) -> bool {
+        self.verbose
+    }
+
+    /// Get the duration specified by the user, that may be marked as working
+    /// between to commits.
+    #[must_use]
+    pub fn duration(&self) -> u32 {
+        self.duration
+    }
+
+    /// Takes the output path, specified by the user, out of `Args`. This should
+    /// therefore only be called once, but saves a unnecessary clone.
+    #[must_use]
+    pub fn take_output(&mut self) -> Option<PathBuf> {
+        self.output.take()
+    }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -238,9 +238,9 @@ pub enum CommitParseError {
     Unknown,
 }
 
-/// The revealed filter creteria.
+/// The revealed filter criteria.
 ///
-/// This data structure allows to filter the input commits by certain creteria.
+/// This data structure allows to filter the input commits by certain criteria.
 #[derive(Debug, Default)]
 pub struct Filter {
     /// A set of substrings to be contained by some authors' names.
@@ -255,8 +255,7 @@ pub struct Filter {
     /// A set of strings to match some commits' hashes.
     commit_equals: Vec<String>,
 
-    /// A set of substrings to be contained by some authors' email
-    /// addresses.
+    /// A set of substrings to be contained by some authors' email addresses.
     email_contains: Vec<String>,
 
     /// A set of strings to match some authors' email addresses.
@@ -520,7 +519,8 @@ pub struct Args {
     #[clap(long)]
     commit_equals: Vec<String>,
 
-    /// Filter loc for certain file extension (e.g. `--file-extension cpp`). ORs if specified multiple times.
+    /// Filter the LOC diff for certain file extension (e.g. `--file-extension
+    /// cpp`). ORs if specified multiple times.
     #[clap(short, long)]
     file_extension: Vec<String>,
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,7 +4,6 @@ use std::path::PathBuf;
 
 use clap::{Parser, Subcommand};
 
-
 /// Parses the Git history.
 #[derive(Parser, Debug)]
 #[clap(version, about, long_about = None)]
@@ -13,7 +12,7 @@ pub struct Args {
     input_method: InputMethod,
 
     /// Always show the entire output.
-    #[clap(short='v', long="verbose")]
+    #[clap(short = 'v', long = "verbose")]
     is_verbose: bool,
 
     /// Filter for certain author names. ORs if specified multiple times.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -494,8 +494,8 @@ pub struct Args {
     input_method: InputMethod,
 
     /// Always show the entire output.
-    #[clap(short, long)]
-    verbose: bool,
+    #[clap(short='v', long="verbose")]
+    is_verbose: bool,
 
     /// Filter for certain author names. ORs if specified multiple times.
     #[clap(short, long)]
@@ -553,7 +553,7 @@ impl Args {
     /// Get the configured verbosity level of the program.
     #[must_use]
     pub fn is_verbose(&self) -> bool {
-        self.verbose
+        self.is_verbose
     }
 
     /// Get the maximum duration between two commits considered spent working.

--- a/src/main.rs
+++ b/src/main.rs
@@ -5,9 +5,9 @@ use clap::Parser;
 fn main() -> sysexits::ExitCode {
     let mut args = commit_analyzer::Args::parse();
 
-    let commits = match args.input_method.read() {
+    let commits = match args.input_method().read() {
         Ok(string) => string,
-        Err(_) => match args.input_method {
+        Err(_) => match args.input_method() {
             commit_analyzer::InputMethod::GitHistory => {
                 eprintln!("Reading from the Git history was not possible.");
                 return sysexits::ExitCode::Unavailable;
@@ -39,9 +39,9 @@ fn main() -> sysexits::ExitCode {
     }
     let mut last_time = None;
     let mut duration = chrono::Duration::zero();
-    let output = args.output.take();
-    let is_verbose = args.verbose;
-    let max_time_difference = args.duration as i64;
+    let output = args.take_output();
+    let is_verbose = args.is_verbose();
+    let max_time_difference = args.duration() as i64;
     let filter = commit_analyzer::Filter::new(args);
     let mut commit_count = 0;
     let mut commits_per_day = HashMap::new();

--- a/src/main.rs
+++ b/src/main.rs
@@ -39,10 +39,7 @@ fn main() -> sysexits::ExitCode {
     }
     let mut last_time = None;
     let mut duration = chrono::Duration::zero();
-    let output = args.take_output();
-    let is_verbose = args.is_verbose();
-    let max_time_difference = args.duration() as i64;
-    let filter = commit_analyzer::Filter::new(args);
+    let filter = args.filter();
     let mut commit_count = 0;
     let mut commits_per_day = HashMap::new();
     let mut loc_per_day = HashMap::new();
@@ -59,12 +56,12 @@ fn main() -> sysexits::ExitCode {
                 .add_assign(commit.loc(&filter));
             if let Some(last_time) = last_time {
                 let diff: chrono::Duration = *commit.date() - last_time;
-                if diff.num_hours() <= max_time_difference {
+                if diff.num_hours() <= args.duration() as i64 {
                     duration = duration + diff;
                 }
             }
             last_time = Some(*commit.date());
-            if is_verbose {
+            if args.is_verbose() {
                 println!("{:#?}", commit);
             }
         }
@@ -73,7 +70,7 @@ fn main() -> sysexits::ExitCode {
     println!("Estimated time was {}h", duration.num_hours());
     println!("Found {} commits overall", commit_count);
 
-    if let Some(path) = output {
+    if let Some(path) = args.take_output() {
         let mut file = match std::fs::File::create(path) {
             Ok(file) => file,
             Err(_) => return sysexits::ExitCode::CantCreat,


### PR DESCRIPTION
> `clap` allows using subcommands, which are helpfull for the input
> methods. This also makes the main method a lot shorter, since there is
> no need to add every single command line option per manually. This is
> handled by the `derive` feature of `clap` and the new `Args` struct.
>
> commit message

I open this pull request to further discuss things and ensure feature equality, before merging it into main.

Pinging @kevinmatthes 